### PR TITLE
Add Veracode GitHub Workflow

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2023 Volkswagen AG
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: "Veracode upload and scan"
+
+on:
+  schedule:
+    # Once a day
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  # Trigger manually
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Zip Project
+        run: zip -r veracode-scan-target.zip ./
+
+      - name: Run Veracode Upload And Scan
+        uses: veracode/veracode-uploadandscan-action@0.2.4
+        with:
+          appname: "PURIS-Frontend"
+          createprofile: false
+          filepath: "./veracode-scan-target.zip"
+          vid: "${{ secrets.VERACODE_API_ID || secrets.ORG_VERACODE_API_ID }}"
+          vkey: "${{ secrets.VERACODE_API_KEY || secrets.ORG_VERACODE_API_KEY }}"


### PR DESCRIPTION
In order to allow Static Application Security Testing (SAST), this pull requests adds a GitHub workflow action to enable analysis with Veracode.