### PR TITLE
fix: added missing variable

### DIFF
--- a/src/views/NegotiationView.vue
+++ b/src/views/NegotiationView.vue
@@ -39,6 +39,7 @@ export default {
     startTransfer(orderId, url) {
       const idArray = orderId.split(":");
       const edcEncoded = encodeURIComponent(url);
+      let vm = this;
       fetch(
         vm.baseUrl +
           "/edc/startTransfer?orderId=" +


### PR DESCRIPTION
in the startTransfer-Method of Negotiation.vue. 

The current implementation of that method was causing an exception after clicking the "Start Transfer"-Button in the "Negotiations"-Menu. Apparently the symbol "vm" was previously not defined/initialised within the body of that method. 